### PR TITLE
Add compatibility for 32bit systems

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -23,6 +23,11 @@
 #include "keyboard.h"
 #include "logging.h"
 
+#ifndef input_event_sec
+#define input_event_sec time.tv_sec
+#define input_event_usec time.tv_usec
+#endif
+
 //static char KBD_DEVICE[256] = "/dev/input/event1";
 static int kbdfd = -1;
 
@@ -53,13 +58,10 @@ void injectKeyEvent(uint16_t code, uint16_t value)
     struct input_event ev;
     memset(&ev, 0, sizeof(ev));
 
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-    gettimeofday(&ev.time, 0);
-#else
     struct timeval time;
     gettimeofday(&time, 0);
-    ev.input_event_sec = (long int)time.tv_sec;
-#endif
+    ev.input_event_sec = time.tv_sec;
+    ev.input_event_usec = time.tv_usec;
 
     ev.type = EV_KEY;
     ev.code = code;
@@ -70,12 +72,8 @@ void injectKeyEvent(uint16_t code, uint16_t value)
     }
 
     // Finally send the SYN
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-    gettimeofday(&ev.time, 0);
-#else
     gettimeofday(&time, 0);
-    ev.input_event_sec = (long int)time.tv_sec;
-#endif
+    ev.input_event_sec = time.tv_sec;
 
     ev.type = EV_SYN;
     ev.code = 0;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -53,7 +53,14 @@ void injectKeyEvent(uint16_t code, uint16_t value)
     struct input_event ev;
     memset(&ev, 0, sizeof(ev));
 
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
     gettimeofday(&ev.time, 0);
+#else
+    struct timeval time;
+    gettimeofday(&time, 0);
+    ev.input_event_sec = (long int)time.tv_sec;
+#endif
+
     ev.type = EV_KEY;
     ev.code = code;
     ev.value = value;
@@ -63,7 +70,13 @@ void injectKeyEvent(uint16_t code, uint16_t value)
     }
 
     // Finally send the SYN
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
     gettimeofday(&ev.time, 0);
+#else
+    gettimeofday(&time, 0);
+    ev.input_event_sec = (long int)time.tv_sec;
+#endif
+
     ev.type = EV_SYN;
     ev.code = 0;
     ev.value = 0;

--- a/src/touch.c
+++ b/src/touch.c
@@ -30,6 +30,11 @@ static int ymin, ymax;
 static int rotate;
 static int trkg_id = -1;
 
+#ifndef input_event_sec
+#define input_event_sec time.tv_sec
+#define input_event_usec time.tv_usec
+#endif
+
 int init_touch(const char *touch_device, int vnc_rotate)
 {
     info_print("Initializing touch device %s ...\n", touch_device);
@@ -104,9 +109,8 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     bool sendTouch;
     int trkIdValue;
     int touchValue;
-#if ! ( (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL) )
     struct timeval time;
-#endif
+
     switch (mouseAction)
     {
     case MousePress:
@@ -133,12 +137,9 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     if (sendTouch)
     {
         // Then send a ABS_MT_TRACKING_ID
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-        gettimeofday(&ev.time, 0);
-#else
         gettimeofday(&time, 0);
-        ev.input_event_sec = (long int)time.tv_sec;
-#endif
+        ev.input_event_sec = time.tv_sec;
+
         ev.type = EV_ABS;
         ev.code = ABS_MT_TRACKING_ID;
         ev.value = trkIdValue;
@@ -148,12 +149,8 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send a BTN_TOUCH
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-        gettimeofday(&ev.time, 0);
-#else
         gettimeofday(&time, 0);
-        ev.input_event_sec = (long int)time.tv_sec;
-#endif
+        ev.input_event_sec = time.tv_sec;
         ev.type = EV_KEY;
         ev.code = BTN_TOUCH;
         ev.value = touchValue;
@@ -166,12 +163,8 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     if (sendPos)
     {
         // Then send a ABS_MT_POSITION_X
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-        gettimeofday(&ev.time, 0);
-#else
         gettimeofday(&time, 0);
-        ev.input_event_sec = (long int)time.tv_sec;
-#endif
+        ev.input_event_sec = time.tv_sec;
         ev.type = EV_ABS;
         ev.code = ABS_MT_POSITION_X;
         ev.value = x;
@@ -181,12 +174,8 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send a ABS_MT_POSITION_Y
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-        gettimeofday(&ev.time, 0);
-#else
         gettimeofday(&time, 0);
-        ev.input_event_sec = (long int)time.tv_sec;
-#endif
+        ev.input_event_sec = time.tv_sec;
         ev.type = EV_ABS;
         ev.code = ABS_MT_POSITION_Y;
         ev.value = y;
@@ -196,12 +185,8 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send the X
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-        gettimeofday(&ev.time, 0);
-#else
         gettimeofday(&time, 0);
-        ev.input_event_sec = (long int)time.tv_sec;
-#endif
+        ev.input_event_sec = time.tv_sec;
         ev.type = EV_ABS;
         ev.code = ABS_X;
         ev.value = x;
@@ -211,12 +196,8 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send the Y
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-        gettimeofday(&ev.time, 0);
-#else
         gettimeofday(&time, 0);
-        ev.input_event_sec = (long int)time.tv_sec;
-#endif
+        ev.input_event_sec = time.tv_sec;
         ev.type = EV_ABS;
         ev.code = ABS_Y;
         ev.value = y;
@@ -227,12 +208,8 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     }
 
     // Finally send the SYN
-#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
-    gettimeofday(&ev.time, 0);
-#else
     gettimeofday(&time, 0);
-    ev.input_event_sec = (long int)time.tv_sec;
-#endif
+    ev.input_event_sec = time.tv_sec;
     ev.type = EV_SYN;
     ev.code = 0;
     ev.value = 0;

--- a/src/touch.c
+++ b/src/touch.c
@@ -104,6 +104,9 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     bool sendTouch;
     int trkIdValue;
     int touchValue;
+#if ! ( (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL) )
+    struct timeval time;
+#endif
     switch (mouseAction)
     {
     case MousePress:
@@ -130,7 +133,12 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     if (sendTouch)
     {
         // Then send a ABS_MT_TRACKING_ID
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
         gettimeofday(&ev.time, 0);
+#else
+        gettimeofday(&time, 0);
+        ev.input_event_sec = (long int)time.tv_sec;
+#endif
         ev.type = EV_ABS;
         ev.code = ABS_MT_TRACKING_ID;
         ev.value = trkIdValue;
@@ -140,7 +148,12 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send a BTN_TOUCH
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
         gettimeofday(&ev.time, 0);
+#else
+        gettimeofday(&time, 0);
+        ev.input_event_sec = (long int)time.tv_sec;
+#endif
         ev.type = EV_KEY;
         ev.code = BTN_TOUCH;
         ev.value = touchValue;
@@ -153,7 +166,12 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     if (sendPos)
     {
         // Then send a ABS_MT_POSITION_X
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
         gettimeofday(&ev.time, 0);
+#else
+        gettimeofday(&time, 0);
+        ev.input_event_sec = (long int)time.tv_sec;
+#endif
         ev.type = EV_ABS;
         ev.code = ABS_MT_POSITION_X;
         ev.value = x;
@@ -163,7 +181,12 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send a ABS_MT_POSITION_Y
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
         gettimeofday(&ev.time, 0);
+#else
+        gettimeofday(&time, 0);
+        ev.input_event_sec = (long int)time.tv_sec;
+#endif
         ev.type = EV_ABS;
         ev.code = ABS_MT_POSITION_Y;
         ev.value = y;
@@ -173,7 +196,12 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send the X
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
         gettimeofday(&ev.time, 0);
+#else
+        gettimeofday(&time, 0);
+        ev.input_event_sec = (long int)time.tv_sec;
+#endif
         ev.type = EV_ABS;
         ev.code = ABS_X;
         ev.value = x;
@@ -183,7 +211,12 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
 
         // Then send the Y
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
         gettimeofday(&ev.time, 0);
+#else
+        gettimeofday(&time, 0);
+        ev.input_event_sec = (long int)time.tv_sec;
+#endif
         ev.type = EV_ABS;
         ev.code = ABS_Y;
         ev.value = y;
@@ -194,7 +227,12 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     }
 
     // Finally send the SYN
+#if (__BITS_PER_LONG != 32 || !defined(__USE_TIME_BITS64)) && !defined(__KERNEL)
     gettimeofday(&ev.time, 0);
+#else
+    gettimeofday(&time, 0);
+    ev.input_event_sec = (long int)time.tv_sec;
+#endif
     ev.type = EV_SYN;
     ev.code = 0;
     ev.value = 0;


### PR DESCRIPTION
On 32bit systems there is no timeval struct in input devices

Signed-off-by: Ettore Chimenti <ek5.chimenti@gmail.com>