### PR TITLE
fixed screen 'smearing' on 1366 X 768 and other displays

### DIFF
--- a/src/framebuffer-vncserver.c
+++ b/src/framebuffer-vncserver.c
@@ -47,6 +47,8 @@
 #define BITS_PER_SAMPLE 5
 #define SAMPLES_PER_PIXEL 2
 
+#define CHANNELS_PER_PIXEL 4
+
 static char fb_device[256] = "/dev/fb0";
 static char touch_device[256] = "";
 static char kbd_device[256] = "";
@@ -114,7 +116,7 @@ static void init_fb(void)
      * This prevents the screen from 'smearing' on 1366 x 768 displays
      */
 
-    fb_xres = fix_scrinfo.line_length / (var_scrinfo.bits_per_pixel / 8);
+    fb_xres = fix_scrinfo.line_length / CHANNELS_PER_PIXEL;
     fb_yres = var_scrinfo.yres;
 
     pixels = fb_xres * fb_yres;

--- a/src/framebuffer-vncserver.c
+++ b/src/framebuffer-vncserver.c
@@ -116,7 +116,7 @@ static void init_fb(void)
      * This prevents the screen from 'smearing' on 1366 x 768 displays
      */
 
-    fb_xres = fix_scrinfo.line_length / CHANNELS_PER_PIXEL;
+    fb_xres = fix_scrinfo.line_length / (var_scrinfo.bits_per_pixel / 8.0);
     fb_yres = var_scrinfo.yres;
 
     pixels = fb_xres * fb_yres;


### PR DESCRIPTION
The current implementation uses the screen resolution retrieved from the fb_var_screeninfo struct which doesn't always match the width of the frame buffer. I fixed the issue by calculating the width of the frame buffer using the line length, which is more accurate.

**Before:**
![smear](https://user-images.githubusercontent.com/2966618/117034468-f3e15680-acc8-11eb-9714-cb193a909324.png)
**After:**
![no_smear](https://user-images.githubusercontent.com/2966618/117034443-edeb7580-acc8-11eb-80a0-73d1d90a4cc2.png)

