### PR TITLE
[add] mouse : add mouse relative coordinates support + rotation : rotating 32 bits/pixel frame buffer + passwd support + [fix] touchscreen pressure detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Using qmake:
 
 	./framebuffer-vncserver [-f device] [-p port] [-t touchscreen] [-m mouse] [-k keyboard] [-r rotation] [-R touchscreen rotation] [-F FPS] [-v] [-h]
 	-p port: VNC port, default is 5900
+	-a authentication: path to password file generated with 'storepasswd'
+	-A authentication: plain text password
 	-f device: framebuffer device node, default is /dev/fb0
 	-k device: keyboard device node (example: /dev/input/event0)
 	-t device: touchscreen device node (example:/dev/input/event2)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with rotation:
 - [ ]  8 bit/pixel
 - [x]  16 bit/pixel
 - [ ]  24 bit/pixel
-- [ ]  32 bit/pixel
+- [x]  32 bit/pixel
 
 The code is based on a LibVNC example for Android:
 https://github.com/LibVNC/libvncserver/blob/master/examples/androidvncserver.c

--- a/src/framebuffer-vncserver.c
+++ b/src/framebuffer-vncserver.c
@@ -706,7 +706,16 @@ int main(int argc, char **argv)
     {
         // init touch only if there is a mouse device defined
         int ret = init_mouse(mouse_device, touch_rotate);
-        enable_mouse = (ret > 0);        
+        if(ret == 3)
+        {
+            info_print("Trying to init with relative coordinates... ");
+            ret = init_mouse_rel(fb_xres, fb_yres, mouse_device, touch_rotate);
+            if(!ret)
+            {
+                info_print("Successful\n");
+            }
+        }
+        enable_mouse = (!ret);        
     }
     else
     {

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -2,5 +2,6 @@
 
 int init_mouse(const char *touch_device, int vnc_rotate);
 int init_mouse_rel(int fb_xres, int fb_yres, const char *touch_device, int vnc_rotate);
+int init_mouse_pos(int first_x, int first_y);
 void cleanup_mouse();
 void injectMouseEvent(struct fb_var_screeninfo *scrinfo, int buttonMask, int x, int y);

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -1,5 +1,6 @@
 #pragma once
 
 int init_mouse(const char *touch_device, int vnc_rotate);
+int init_mouse_rel(int fb_xres, int fb_yres, const char *touch_device, int vnc_rotate);
 void cleanup_mouse();
 void injectMouseEvent(struct fb_var_screeninfo *scrinfo, int buttonMask, int x, int y);

--- a/src/touch.c
+++ b/src/touch.c
@@ -109,6 +109,7 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     bool sendTouch;
     int trkIdValue;
     int touchValue;
+    int pressureValue;
     struct timeval time;
 
     switch (mouseAction)
@@ -118,12 +119,14 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         sendTouch = true;
         trkIdValue = ++trkg_id;
         touchValue = 1;
+        pressureValue = 11;
         break;
     case MouseRelease:
         sendPos = false;
         sendTouch = true;
         trkIdValue = -1;
         touchValue = 0;
+        pressureValue = 0;
         break;
     case MouseDrag:
         sendPos = true;
@@ -212,6 +215,17 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         }
     }
 
+    gettimeofday(&time, 0);
+    ev.input_event_sec = time.tv_sec;
+    ev.input_event_usec = time.tv_usec;
+    ev.type = EV_ABS;
+    ev.code = ABS_PRESSURE;
+    ev.value = pressureValue;
+    if (write(touchfd, &ev, sizeof(ev)) < 0)
+    {
+        error_print("write event failed, %s\n", strerror(errno));
+    }
+
     // Finally send the SYN
     gettimeofday(&time, 0);
     ev.input_event_sec = time.tv_sec;
@@ -223,5 +237,5 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     {
         error_print("write event failed, %s\n", strerror(errno));
     }
-    debug_print("injectTouchEvent (screen(%d,%d) -> touch(%d,%d), mouse=%d)\n", xin, yin, x, y, mouseAction);
+    info_print("injectTouchEvent (screen(%d,%d) -> touch(%d,%d), mouse=%d)\n", xin, yin, x, y, mouseAction);
 }

--- a/src/touch.c
+++ b/src/touch.c
@@ -98,10 +98,10 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
     // Calculate the final x and y
     /* Fake touch screen always reports zero */
     //???//if (xmin != 0 && xmax != 0 && ymin != 0 && ymax != 0)
-    {
-        x = xmin + (x * (xmax - xmin)) / (scrinfo->xres);
-        y = ymin + (y * (ymax - ymin)) / (scrinfo->yres);
-    }
+    // {
+    //     x = xmin + (x * (xmax - xmin)) / (scrinfo->xres);
+    //     y = ymin + (y * (ymax - ymin)) / (scrinfo->yres);
+    // }
 
     memset(&ev, 0, sizeof(ev));
 
@@ -213,18 +213,30 @@ void injectTouchEvent(enum MouseAction mouseAction, int x, int y, struct fb_var_
         {
             error_print("write event failed, %s\n", strerror(errno));
         }
+        
+        gettimeofday(&time, 0);
+        ev.input_event_sec = time.tv_sec;
+        ev.input_event_usec = time.tv_usec;
+        ev.type = EV_ABS;
+        ev.code = ABS_PRESSURE;
+        ev.value = pressureValue;
+        if (write(touchfd, &ev, sizeof(ev)) < 0)
+        {
+            error_print("write event failed, %s\n", strerror(errno));
+        }
+    
+        gettimeofday(&time, 0);
+        ev.input_event_sec = time.tv_sec;
+        ev.input_event_usec = time.tv_usec;
+        ev.type = EV_ABS;
+        ev.code = ABS_MT_PRESSURE;
+        ev.value = pressureValue;
+        if (write(touchfd, &ev, sizeof(ev)) < 0)
+        {
+            error_print("write event failed, %s\n", strerror(errno));
+        }
     }
 
-    gettimeofday(&time, 0);
-    ev.input_event_sec = time.tv_sec;
-    ev.input_event_usec = time.tv_usec;
-    ev.type = EV_ABS;
-    ev.code = ABS_PRESSURE;
-    ev.value = pressureValue;
-    if (write(touchfd, &ev, sizeof(ev)) < 0)
-    {
-        error_print("write event failed, %s\n", strerror(errno));
-    }
 
     // Finally send the SYN
     gettimeofday(&time, 0);


### PR DESCRIPTION
* Some mice don't support absolute coordinate control ; this fix solves this by adding support for relative coordinate control.
* Added support for 32 bits/pixel frame buffer rotation

Tested on:
* Host : Custom Yocto image for Raspberry pi 3b+
* Client : UltraVNC Viewer on Windows