### PR TITLE
Rework CMakeLists.txt: Bump min version to 3.10 + improvements

### DIFF
--- a/.travis.yml.bak
+++ b/.travis.yml.bak
@@ -1,8 +1,0 @@
-language: c
-install:
- - sudo apt-get update -qq
- - sudo apt-get install -y libvncserver-dev cmake qt4-qmake 
-
-script:  
- - mkdir -p build1 && cd build1 && cmake .. && make && cd ..
- - mkdir -p build2 && cd build2 && qmake ../framebuffer-vncserver.pro && make && cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,32 @@
-PROJECT(framebuffer-vncserver)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
+
+project(framebuffer-vncserver
+  LANGUAGES C
+  DESCRIPTION "VNC server for Linux framebuffer devices"
+  HOMEPAGE_URL "https://github.com/ponty/framebuffer-vncserver"
+)
 
 
-FILE(GLOB SOURCES src/*.c)
-ADD_EXECUTABLE(framebuffer-vncserver ${SOURCES})
-INSTALL(TARGETS framebuffer-vncserver RUNTIME DESTINATION bin)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+# aka link-time-optimization (LTO)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+
+# https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
+add_compile_options(
+  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -Wall -Wextra -Wpedantic
+
+  -Wstack-protector -fstack-clash-protection -fstack-protector-strong
+  -Wformat=2 -Wformat-nonliteral -Wwrite-strings -Werror=format-security
+)
+
+
+file(GLOB SOURCES src/*.c)
+add_executable(${PROJECT_NAME} ${SOURCES})
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 
 # LIBVNC
-find_library(LIBVNC NAMES libvncserver vncserver)
-target_link_libraries(framebuffer-vncserver ${LIBVNC})
+find_library(LIBVNC NAMES libvncserver vncserver REQUIRED)
+target_link_libraries(${PROJECT_NAME} ${LIBVNC})
 
 
-MESSAGE( STATUS "LIBVNC:         " ${LIBVNC} )
+message(STATUS "LIBVNC:         " ${LIBVNC})


### PR DESCRIPTION
The main point is that cmake 4.0 requires a newer version than 3.5 and suggests 3.10. Otherwise, it fails to build.